### PR TITLE
Fix small typo on GTK video player post

### DIFF
--- a/posts/2017-08-30-haskell-gtk-video-player.markdown
+++ b/posts/2017-08-30-haskell-gtk-video-player.markdown
@@ -336,7 +336,7 @@ We give this element the name `MultimediaPlayer`.
 
 #### Embedding the GStreamer output
 
-Two bring together GTK+ and GStreamer, we need a way to tell GStreamer where to render the video to.
+To bring together GTK+ and GStreamer, we need a way to tell GStreamer where to render the video to.
 If we do not tell GStreamer where to render to, it will create its own window since we are using `playbin`.
 
 ```haskell


### PR DESCRIPTION
"Two bring together" -> "To bring together"